### PR TITLE
bump dockview-core to 1.17.1

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -129,7 +129,7 @@ const App = () => {
   );
 };
 
-function ComplexExamplePanel(props: {}) {
+function ComplexExamplePanel(_props: {}) {
   const [title, setTitle] = createSignal("hello");
   const [closable, setClosable] = createSignal(true);
   const [starred, setStarred] = createSignal(false);

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -39,10 +39,8 @@ const App = () => {
     ]);
 
     // after next rendering, move the panel to given group
-    createEffect(() => {
-      const panel = currentDockview.panels.find((x) => x.id === id);
-      panel?.api.moveTo({ group });
-    });
+    const panel = currentDockview.panels.find((x) => x.id === id);
+    panel?.api.moveTo({ group });
   }
 
   return (

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -145,7 +145,7 @@ function ComplexExamplePanel(props: {}) {
       }
       closeable={closable()}
       actions={[
-        <button class="tab-action" onClick={() => setStarred((v) => !v)} title="Toggle Star">
+        <button class="dv-default-tab-action" onClick={() => setStarred((v) => !v)} title="Toggle Star">
           <StarSVG filled={starred()} />
         </button>,
       ]}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Docking Layout for Solid.js, based on dockview-core",
   "type": "module",
   "main": "dist/index.js",
+  "packageManager": "pnpm@8.11.0",
   "scripts": {
     "prepack": "npm run build",
     "build": "vite build",
@@ -29,7 +30,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
-    "dockview-core": "^1.8.5",
+    "dockview-core": "^1.17.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.0",
@@ -42,7 +43,7 @@
     "vite-plugin-solid": "^2.8.0"
   },
   "peerDependencies": {
-    "dockview-core": "^1.8.5",
+    "dockview-core": "^1.17.1",
     "solid-js": "^1.8.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ devDependencies:
     specifier: ^6.15.0
     version: 6.15.0(eslint@8.56.0)(typescript@5.3.3)
   dockview-core:
-    specifier: ^1.8.5
-    version: 1.8.5
+    specifier: ^1.17.1
+    version: 1.17.1
   eslint:
     specifier: ^8.56.0
     version: 8.56.0
@@ -901,6 +901,10 @@ packages:
       string-argv: 0.3.2
     dev: true
 
+  /@types/argparse@1.0.38:
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    dev: true
+
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
@@ -1431,8 +1435,8 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /dockview-core@1.8.5:
-    resolution: {integrity: sha512-ryhqBpxvQ2U43b5kFO86M7ty+ElLJ4fxaVKvWr/2QatKyc6/oScc5jIYu0zveyHs6iAbbY+z7igOJSSsFtDw3w==}
+  /dockview-core@1.17.1:
+    resolution: {integrity: sha512-lSdArYw1pH++1G8yv2OJtt3Pdp52YYGHr/pguaOTnVILRUzDpusYs/qmnNeb8ejpU87MqIeuuqfx+6d/A6T4Lg==}
     dev: true
 
   /doctrine@3.0.0:
@@ -2733,10 +2737,4 @@ packages:
       validator: 13.11.0
     optionalDependencies:
       commander: 9.5.0
-    dev: true
-
-  /@types/argparse@1.0.38:
-    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
-    name: '@types/argparse'
-    version: 1.0.38
     dev: true

--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -19,13 +19,13 @@ export type DockPanelProps = ParentProps<{
   /** custom class name for content wrapper. default: "solid-dockview-panel-content" */
   class?: string;
 
-  /** custom class name for content wrapper. default: "default-tab" */
+  /** custom class name for content wrapper. default: "dv-default-tab" */
   tabClass?: string;
 
   /** set to false to hide closing button */
   closeable?: boolean;
 
-  /** one or more buttons before "close button", typically is `<div class="tab-action"> ... </div>` */
+  /** one or more buttons before "close button", typically is `<div class="dv-default-tab-action"> ... </div>` */
   actions?: JSXElement | JSXElement[];
 
   floating?: AddPanelOptions["floating"];
@@ -143,7 +143,7 @@ function setupTab(props: DockPanelProps, panel: DockviewPanel, placeholder: HTML
     }
   });
 
-  const className = createMemo(() => props.tabClass || "default-tab");
+  const className = createMemo(() => props.tabClass || "dv-default-tab");
   return createMemo(() => (
     <Portal
       mount={placeholder}
@@ -151,14 +151,14 @@ function setupTab(props: DockPanelProps, panel: DockviewPanel, placeholder: HTML
         createEffect(() => (div.className = className()));
       }}
     >
-      {/* <div class="default-tab"> */}
-      <div class="tab-content">{computedTitle()}</div>
+      {/* <div class="dv-default-tab"> */}
+      <div class="dv-default-tab-content">{computedTitle()}</div>
       <div class="action-container" onMouseDown={(e) => e.preventDefault()}>
         <ul class="tab-list">
           {props.actions}
           {!!(props.closeable ?? true) && (
             <div
-              class="tab-action"
+              class="dv-default-tab-action"
               onClick={(e) => {
                 panel.api.close();
                 e.preventDefault();

--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -154,7 +154,7 @@ function setupTab(props: DockPanelProps, panel: DockviewPanel, placeholder: HTML
       {/* <div class="dv-default-tab"> */}
       <div class="dv-default-tab-content">{computedTitle()}</div>
       <div class="action-container" onMouseDown={(e) => e.preventDefault()}>
-        <ul class="tab-list">
+        <ul class="solid-dockview-tab-list">
           {props.actions}
           {!!(props.closeable ?? true) && (
             <div

--- a/src/DockView.tsx
+++ b/src/DockView.tsx
@@ -23,7 +23,6 @@ export type DockViewProps = ParentProps<
     prefixHeaderActionsComponent?: (props: DockViewGroupHeaderComponentProps) => JSX.Element;
     rightHeaderActionsComponent?: (props: DockViewGroupHeaderComponentProps) => JSX.Element;
 
-    orientation?: DockviewComponentOptions["orientation"];
     singleTabMode?: DockviewComponentOptions["singleTabMode"];
     disableFloatingGroups?: DockviewComponentOptions["disableFloatingGroups"];
     floatingGroupBounds?: DockviewComponentOptions["floatingGroupBounds"];
@@ -43,7 +42,6 @@ export const dockViewPropKeys = strictKeys<DockViewProps>()([
   "prefixHeaderActionsComponent",
   "rightHeaderActionsComponent",
 
-  "orientation",
   "singleTabMode",
   "disableFloatingGroups",
   "floatingGroupBounds",

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -11,7 +11,7 @@ import {
   PanelContentRenderer,
   PanelTabRenderer,
   createGroupHeaderComponent,
-  createWatermarkComponent,
+  WatermarkComponent,
 } from "./glue-component";
 
 export const DockViewContext = createContext<ReturnType<typeof createDockViewContext>>();
@@ -29,22 +29,21 @@ export function createDockViewContext(props: DockViewProps) {
   };
 
   const options: DockviewComponentOptions = {
-    parentElement: element,
-    components: {
-      default: PanelContentRenderer,
-    },
-    tabComponents: {
-      default: PanelTabRenderer,
-    },
+    createComponent: () => new PanelContentRenderer(),
+    createTabComponent: () => new PanelTabRenderer(),
     singleTabMode: props.singleTabMode,
-    watermarkComponent: createWatermarkComponent(props, addExtraRender),
-    createPrefixHeaderActionsElement: createGroupHeaderComponent(props, "prefixHeaderActionsComponent", addExtraRender),
-    createLeftHeaderActionsElement: createGroupHeaderComponent(props, "leftHeaderActionsComponent", addExtraRender),
-    createRightHeaderActionsElement: createGroupHeaderComponent(props, "rightHeaderActionsComponent", addExtraRender),
+    createWatermarkComponent: () => new WatermarkComponent(props, addExtraRender),
+    createPrefixHeaderActionComponent: createGroupHeaderComponent(
+      props,
+      "prefixHeaderActionsComponent",
+      addExtraRender,
+    ),
+    createLeftHeaderActionComponent: createGroupHeaderComponent(props, "leftHeaderActionsComponent", addExtraRender),
+    createRightHeaderActionComponent: createGroupHeaderComponent(props, "rightHeaderActionsComponent", addExtraRender),
   };
 
   props.onBeforeCreate?.(options, props);
-  const dockview = new DockviewComponent(options);
+  const dockview = new DockviewComponent(element, options);
 
   // add event listeners
   dockviewEventNames.forEach((eventName) => {

--- a/src/style.scss
+++ b/src/style.scss
@@ -2,6 +2,14 @@
   display: contents;
 }
 
+// from https://github.com/mathuo/dockview/commit/4a9a791047c666453c1c677de5859cc833d1746b#diff-fe0e085aef487d548e00919328962e65b3055d6ae52cada7905777a8037039c6L72-L76
+.solid-dockview-tab-list {
+  display: flex;
+  padding: 0px;
+  margin: 0px;
+  justify-content: flex-end;
+}
+
 /* in case <button> */
 .dv-default-tab .dv-default-tab-action {
   border: 0;

--- a/src/style.scss
+++ b/src/style.scss
@@ -3,7 +3,7 @@
 }
 
 /* in case <button> */
-.default-tab .tab-action {
+.dv-default-tab .dv-default-tab-action {
   border: 0;
   background: transparent;
   cursor: pointer;


### PR DESCRIPTION
[Dockview doesn't follow semver](https://github.com/mathuo/dockview/issues/711), so we need to update the css and typescript in order to use the latest (v1.17.1)

The commits are more or less "atomic", so please feel free to step through them to review.